### PR TITLE
return response for expired/invalid cookie on getSessionInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,17 @@ module.exports = {
         data: sessionInfoResponse.data,
       };
     } catch (err) {
-      throw new AgentlessWebssoError('Error getting session info for cookie', err.response.status, err.response.data);
+      // NOTE Apigee returns a 500 status when the cookie is not valid even though OpenAM returns a 401 when the cookie is not valid 
+      if (err.response.data.fault.faultstring.includes("ResponseCode 401 is treated as error")){
+        console.log('nusso node package | Apigee AgentlessWebsso returned 500 when cookie not logged in. returning 401 openAM body for use with isLoggedIn method instead of throwing 500');
+        return {
+          "code": 401,
+          "reason": "Unauthorized",
+          "message": "Access Denied"
+        };
+      } else {
+        throw new AgentlessWebssoError('Error getting session info for cookie', err.response.status, err.response.data);
+      }
     }
   },
 


### PR DESCRIPTION
before the Apigee layer was added, we discussed that if the getSessionInfo API returned the netID in the body the cookie was logged in, and if the netID was not in the response body the cookie was not logged in. Originally the nusso package configured axios not to treat a 401 as an error and the calling application could get the session info for the cookie and pass session info to check if logged in (these were designed to be separate methods because the session info is used to check if user is DUOed, get netID of logged in user, etc. and is not only for validating a cookie is logged in): 
```
const sessionInfo = await nusso.getSessionInfo(ssoCookie, AUTH_ENV, AUTH_APIKEY);
// Use session info to determine whether they are authenticated
const isLoggedIn = nusso.isLoggedIn(sessionInfo); // returns presence of netid in sessionInfo
```

The agentless websso Apigee proxy returns a 401 if there is a problem with the Apigee APIKEY, so I returned axios to treating the 401 as an error. The Apigee proxy returns a 500 error and a fault string about the service callout when the cookie is invalid instead of the 401 status and unauthorized object that OpenAM returns. So now, adding a check in the catch whether the Apigee error body contains the string about the 401 from the Apigee service callout and if so, return the 401 body object as the data, so it can be used with isLoggedIn method. 